### PR TITLE
Fix to reconnect to Redis

### DIFF
--- a/notifier/redis.go
+++ b/notifier/redis.go
@@ -601,11 +601,11 @@ func (s *Supervisor) redisSubscriberLoop() error {
 			var er EventRequest
 			err := json.Unmarshal(v.Data, &er)
 			if err != nil {
-				s.logger.Infow("redis message decoding error", "error", err, "message", v.Data)
+				s.logger.Errorw("redis message decoding error", "error", err, "message", v.Data)
 			} else {
 				apperr := s.handleRedisEventRequest(&er)
 				if apperr != nil {
-					s.logger.Infow("redis message handle error", "appError", apperr, "message", er)
+					s.logger.Errorw("redis message handle error", "appError", apperr, "message", er)
 				}
 			}
 		case error:

--- a/notifier/redis.go
+++ b/notifier/redis.go
@@ -574,46 +574,54 @@ func (db *DB) GetAllUserIDs(appname string) ([]int, error) {
 // Redis push event handling
 //
 
-func (s *Supervisor) redisSubscriberLoop() {
+func (s *Supervisor) redisSubscriberLoop() error {
 	c, err := s.db.getPool()
 	if err != nil {
-		s.logger.Errorw("PubSubConn failed to get pool",
-			"error", err)
-		return
+		s.logger.Errorw("PubSubConn failed to get pool", "error", err)
+		return err
 	}
 	defer c.Close()
 
 	psc := redis.PubSubConn{Conn: c}
 	err = psc.Subscribe("events")
 	if err != nil {
-		s.logger.Errorw("PubSubConn Subscribe failed",
-			"error", err)
-		return
+		s.logger.Errorw("PubSubConn Subscribe failed", "error", err)
+		return err
 	}
+	defer func() {
+		if err := psc.Close(); err != nil {
+			s.logger.Errorw("PubSubConn Close failed", "error", err)
+			return
+		}
+	}()
+
 	for {
 		switch v := psc.Receive().(type) {
 		case redis.Message:
 			var er EventRequest
 			err := json.Unmarshal(v.Data, &er)
 			if err != nil {
-				s.logger.Infow("redis message decoding error",
-					"error", err,
-					"message", v.Data)
+				s.logger.Infow("redis message decoding error", "error", err, "message", v.Data)
 			} else {
 				apperr := s.handleRedisEventRequest(&er)
 				if apperr != nil {
-					s.logger.Infow("redis message handle error",
-						"appError", apperr,
-						"message", er)
+					s.logger.Infow("redis message handle error", "appError", apperr, "message", er)
 				}
 			}
 		case error:
-			if strings.Contains(v.(error).Error(), "use of closed network") {
-				_ = psc.Close()
-				return
-			}
-			s.logger.Infow("redis error event", "error", v)
+			return v
 		}
+	}
+}
+
+func (s *Supervisor) redisSubscriberLoopWithRetry() {
+	for {
+		err := s.redisSubscriberLoop()
+		if strings.Contains(err.Error(), "use of closed network") {
+			return
+		}
+
+		time.Sleep(5 * time.Second)
 	}
 }
 
@@ -634,7 +642,7 @@ func (s *Supervisor) handleRedisEventRequest(er *EventRequest) error {
 // KickRedisSubscription starts goroutine to handle Redis events.
 func (s *Supervisor) KickRedisSubscription() {
 	if s.db != nil {
-		go s.redisSubscriberLoop()
+		go s.redisSubscriberLoopWithRetry()
 	}
 }
 

--- a/notifier/redis.go
+++ b/notifier/redis.go
@@ -609,6 +609,7 @@ func (s *Supervisor) redisSubscriberLoop() error {
 				}
 			}
 		case error:
+			s.logger.Errorw("redis error event", "error", v)
 			return v
 		}
 	}

--- a/notifier/redis_test.go
+++ b/notifier/redis_test.go
@@ -211,7 +211,7 @@ func TestLowlevelBroadcast(t *testing.T) {
 }
 
 func TestLowlevelBroadcast_reconnection(t *testing.T) {
-	// execute this integration prepared Redis using brew on Mac ONLY.
+	// execute this integration test with Redis installed by Homebrew
 	if err := exec.Command("bash", "-c", "brew list | grep redis").Run(); err != nil {
 		return // skip this test
 	}
@@ -251,7 +251,7 @@ func TestLowlevelBroadcast_reconnection(t *testing.T) {
 		Channel:     "chan0"},
 		ersave)
 
-	// re-send under stopped redis
+	// re-send to stopped redis
 	err = exec.Command("bash", "-c", "brew services stop redis").Run()
 	require.NoError(t, err)
 	time.Sleep(500 * time.Millisecond)

--- a/notifier/redis_test.go
+++ b/notifier/redis_test.go
@@ -1,4 +1,4 @@
-// +build redis_test, redis_sentinel_test
+// +build redis_test redis_sentinel_test
 
 package notifier
 

--- a/notifier/redis_test.go
+++ b/notifier/redis_test.go
@@ -4,6 +4,7 @@ package notifier
 
 import (
 	"net/http"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -203,6 +204,76 @@ func TestLowlevelBroadcast(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	require.Equal(t, &EventRequest{Name: "event-name",
+		Data:        "event-data",
+		Application: "testapp",
+		Channel:     "chan0"},
+		ersave)
+}
+
+func TestLowlevelBroadcast_reconnection(t *testing.T) {
+	// execute this integration prepared Redis using brew on Mac ONLY.
+	if err := exec.Command("bash", "-c", "brew list | grep redis").Run(); err != nil {
+		return // skip this test
+	}
+
+	err := exec.Command("bash", "-c", "brew services restart redis").Run()
+	require.NoError(t, err)
+	time.Sleep(500 * time.Millisecond)
+
+	s := initRedisTest(t)
+	defer s.Finish()
+
+	u, apperr := s.AddUser("testapp", nil)
+	require.Nil(t, apperr)
+	require.Equal(t, 0, u.ID)
+	u, apperr = s.AddUser("testapp", nil)
+	require.NoError(t, apperr)
+	require.Equal(t, 1, u.ID)
+
+	_, apperr = s.GetOrCreateChannel("testapp", "chan0")
+	require.Nil(t, apperr)
+
+	var ersave *EventRequest
+	s.db.eventCallback = func(er *EventRequest) bool {
+		ersave = er
+		return false
+	}
+
+	a, _ := s.GetApp("testapp")
+	apperr = s.Broadcast(a, &Event{Name: "event-name", Data: "event-data"}, "chan0")
+	require.NoError(t, apperr)
+	time.Sleep(500 * time.Millisecond)
+
+	require.Equal(t, &EventRequest{
+		Name:        "event-name",
+		Data:        "event-data",
+		Application: "testapp",
+		Channel:     "chan0"},
+		ersave)
+
+	// re-send under stopped redis
+	err = exec.Command("bash", "-c", "brew services stop redis").Run()
+	require.NoError(t, err)
+	time.Sleep(500 * time.Millisecond)
+
+	ersave = nil
+	apperr = s.Broadcast(a, &Event{Name: "event-name", Data: "event-data"}, "chan0")
+	require.Error(t, apperr)
+
+	time.Sleep(5000 * time.Millisecond)
+	require.Nil(t, ersave)
+
+	// start redis
+	err = exec.Command("bash", "-c", "brew services start redis").Run()
+	require.NoError(t, err)
+	time.Sleep(5000 * time.Millisecond)
+
+	apperr = s.Broadcast(a, &Event{Name: "event-name", Data: "event-data"}, "chan0")
+	require.NoError(t, apperr)
+	time.Sleep(500 * time.Millisecond)
+
+	require.Equal(t, &EventRequest{
+		Name:        "event-name",
 		Data:        "event-data",
 		Application: "testapp",
 		Channel:     "chan0"},


### PR DESCRIPTION
クライアントに通知を送る際、
RedisのPubSub機能を使って、対象Clientにメッセージを送信しているが、
Subscribeを常時受け付ける `for` ループ内でエラーが発生した場合、
Connectionの再接続を行わず、Receiveを行う実装になっている

RedisがFail Over した時など、Reidsサーバにアクセスできなかったときに、
connectionを再作成する様に修正する。